### PR TITLE
[#13198] Updated exceptions to retry list

### DIFF
--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -103,6 +103,10 @@ module NetSuite
         exceptions_to_retry << OpenSSL::SSL::SSLErrorWaitReadable if defined?(OpenSSL::SSL::SSLErrorWaitReadable)
 
         # depends on the http library chosen
+        exceptions_to_retry << HTTPClient::TimeoutError if defined?(HTTPClient::TimeoutError)
+        exceptions_to_retry << HTTPClient::ConnectTimeoutError if defined?(HTTPClient::ConnectTimeoutError)
+        exceptions_to_retry << HTTPClient::ReceiveTimeoutError if defined?(HTTPClient::ReceiveTimeoutError)
+        exceptions_to_retry << HTTPClient::SendTimeoutError if defined?(HTTPClient::SendTimeoutError)
         exceptions_to_retry << Excon::Error::Timeout if defined?(Excon::Error::Timeout)
         exceptions_to_retry << Excon::Error::Socket if defined?(Excon::Error::Socket)
 


### PR DESCRIPTION
## Depend on:
https://git.shiphawk.com/shiphawk/shiphawk-dev/-/merge_requests/13968

## Ticket:
https://pm.shiphawk.com/issues/13198

## Description:
This ticket is based on the latest [NS build code](https://github.com/NetSweet/netsuite/blob/1ee55275561261acf3c15dde6782cc29fd5c7b1b/lib/netsuite/utilities.rb#L106-L109)

Actually we need to retry requests with such kind of responses

It is based on next PR to original gem: [Link 1](https://github.com/NetSweet/netsuite/pull/514) and [Link 2](https://github.com/NetSweet/netsuite/pull/524)
